### PR TITLE
feat(voice): add speech-to-text input with language toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ An AI-powered language tutor leveraging adaptive CEFR-aligned pedagogy and real-
 ## Features
 
 - **Adaptive Conversations** - Vocabulary and grammar adjust to your CEFR level (A1-C2)
-- **Multi-Language Support** - English, Spanish, French, German, Mandarin, Japanese, Portuguese, Arabic, Russian, Hindi
+- **Multi-Language Support** - 70+ languages including English, Spanish, French, German, Mandarin, Japanese, Portuguese, Arabic, Russian, Hindi
 - **Multiple LLM Providers** - Choose between Anthropic, OpenAI, or OpenRouter
 - **Contextual Feedback** - Real-time corrections, translations, IPA phonetics
-- **Text-to-Speech** - Native pronunciation synthesis
+- **Text-to-Speech** - Native pronunciation synthesis for all supported languages
+- **Voice Input** - Browser-based speech-to-text with support for both native and target languages
 - **Session Management** - Save and resume configurations
 
 ## Quick Start
@@ -100,5 +101,21 @@ mix ecto.setup && mix phx.server
 ```
 
 Visit [localhost:4000](http://localhost:4000)
+
+## Using Voice Input
+
+Dialekt supports browser-based speech-to-text for hands-free language practice:
+
+1. **Start recording** - Click the microphone button next to the text input
+2. **Switch languages** - Click the language badge (e.g., "DE" or "EN") that appears while recording to toggle between your native and target language
+3. **Speak naturally** - The waveform visualizes your voice input in real-time
+4. **Stop recording** - Click the stop button or simply finish speaking (recognition ends automatically)
+5. **Review transcript** - Your speech is transcribed and appears in the text input for you to review before sending
+
+**Notes:**
+- Voice input uses the Web Speech API (requires internet connection)
+- Supports 70+ languages with varying quality depending on browser support
+- Works best in Chrome/Brave (may require disabling privacy shields for localhost)
+- Recognition accuracy depends on microphone quality, accent, and language
 
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -105,3 +105,121 @@
 /* This file is for your main application CSS */
 @import "./dialekt.css";
 @import "./tts.css";
+
+/* Voice Input Styles */
+.input-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  position: relative;
+}
+
+.voice-input-btn {
+  padding: 0.5rem;
+  background: var(--color-base-200);
+  border: var(--border) solid var(--color-base-300);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.voice-input-btn:hover {
+  background: var(--color-base-300);
+}
+
+.voice-input-btn:focus {
+  outline: 2px solid var(--color-base-content);
+  outline-offset: 2px;
+}
+
+.voice-input-btn .stop-icon {
+  display: none;
+}
+
+.voice-input-btn.recording {
+  background: var(--color-base-content);
+  border-color: var(--color-base-content);
+  color: var(--color-base-100);
+}
+
+.voice-input-btn.recording .mic-icon {
+  display: none;
+}
+
+.voice-input-btn.recording .stop-icon {
+  display: block;
+}
+
+.waveform-canvas {
+  display: none;
+  width: 100%;
+  height: 60px;
+  margin-top: 0.5rem;
+  border-radius: 0.5rem;
+  background: var(--color-base-200);
+}
+
+.recording-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-base-content);
+  opacity: 0.7;
+}
+
+.recording-dot {
+  width: 8px;
+  height: 8px;
+  background: var(--color-base-content);
+  border-radius: 50%;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .recording-dot {
+    animation: none;
+  }
+}
+
+.lang-toggle-btn {
+  padding: 0.25rem 0.5rem;
+  margin-left: auto;
+  background: var(--color-base-200);
+  border: var(--border) solid var(--color-base-300);
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.lang-toggle-btn:hover {
+  background: var(--color-base-300);
+}
+
+.lang-toggle-btn.target-lang {
+  background: var(--color-base-content);
+  border-color: var(--color-base-content);
+  color: var(--color-base-100);
+}
+
+.lang-toggle-btn.native-lang {
+  background: var(--color-base-200);
+  border-color: var(--color-base-300);
+  color: var(--color-base-content);
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -27,6 +27,92 @@ import topbar from "../vendor/topbar"
 
 const Hooks = {}
 
+// VoiceInput configuration constants
+const VOICE_INPUT_CONFIG = {
+  LANG_SWITCH_DELAY_MS: 100,
+  FFT_SIZE: 256,
+  WAVEFORM_BAR_COUNT: 40,
+  WAVEFORM_HEIGHT_SCALE: 0.8,
+  WAVEFORM_BAR_GAP: 2
+}
+
+// Language to locale mapping for speech APIs (70+ languages)
+// Shared between TextToSpeech and VoiceInput hooks
+const LANG_TO_LOCALE = {
+  // Verified languages (15) - known good Web Speech API support
+  'en': 'en-GB',
+  'es': 'es-ES',
+  'fr': 'fr-FR',
+  'de': 'de-DE',
+  'it': 'it-IT',
+  'pt': 'pt-BR',
+  'ja': 'ja-JP',
+  'ko': 'ko-KR',
+  'zh': 'zh-CN',
+  'ru': 'ru-RU',
+  'ar': 'ar-SA',
+  'hi': 'hi-IN',
+  'nl': 'nl-NL',
+  'pl': 'pl-PL',
+  'sv': 'sv-SE',
+
+  // Additional languages (55+)
+  'af': 'af-ZA',   // Afrikaans - South Africa
+  'sq': 'sq-AL',   // Albanian - Albania
+  'hy': 'hy-AM',   // Armenian - Armenia
+  'az': 'az-AZ',   // Azerbaijani - Azerbaijan
+  'bn': 'bn-BD',   // Bengali - Bangladesh
+  'bs': 'bs-BA',   // Bosnian - Bosnia
+  'bg': 'bg-BG',   // Bulgarian - Bulgaria
+  'ca': 'ca-ES',   // Catalan - Spain
+  'hr': 'hr-HR',   // Croatian - Croatia
+  'cs': 'cs-CZ',   // Czech - Czech Republic
+  'da': 'da-DK',   // Danish - Denmark
+  'et': 'et-EE',   // Estonian - Estonia
+  'fi': 'fi-FI',   // Finnish - Finland
+  'ka': 'ka-GE',   // Georgian - Georgia
+  'el': 'el-GR',   // Greek - Greece
+  'gu': 'gu-IN',   // Gujarati - India
+  'ht': 'ht-HT',   // Haitian Creole - Haiti
+  'he': 'he-IL',   // Hebrew - Israel
+  'hu': 'hu-HU',   // Hungarian - Hungary
+  'is': 'is-IS',   // Icelandic - Iceland
+  'id': 'id-ID',   // Indonesian - Indonesia
+  'ga': 'ga-IE',   // Irish - Ireland
+  'kn': 'kn-IN',   // Kannada - India
+  'kk': 'kk-KZ',   // Kazakh - Kazakhstan
+  'km': 'km-KH',   // Khmer - Cambodia
+  'lv': 'lv-LV',   // Latvian - Latvia
+  'lt': 'lt-LT',   // Lithuanian - Lithuania
+  'mk': 'mk-MK',   // Macedonian - North Macedonia
+  'ms': 'ms-MY',   // Malay - Malaysia
+  'ml': 'ml-IN',   // Malayalam - India
+  'mt': 'mt-MT',   // Maltese - Malta
+  'mr': 'mr-IN',   // Marathi - India
+  'mn': 'mn-MN',   // Mongolian - Mongolia
+  'ne': 'ne-NP',   // Nepali - Nepal
+  'nb': 'nb-NO',   // Norwegian - Norway
+  'fa': 'fa-IR',   // Persian - Iran
+  'pa': 'pa-IN',   // Punjabi - India
+  'ro': 'ro-RO',   // Romanian - Romania
+  'sr': 'sr-RS',   // Serbian - Serbia
+  'sk': 'sk-SK',   // Slovak - Slovakia
+  'sl': 'sl-SI',   // Slovenian - Slovenia
+  'so': 'so-SO',   // Somali - Somalia
+  'sw': 'sw-KE',   // Swahili - Kenya
+  'tl': 'tl-PH',   // Tagalog - Philippines
+  'ta': 'ta-IN',   // Tamil - India
+  'te': 'te-IN',   // Telugu - India
+  'th': 'th-TH',   // Thai - Thailand
+  'tr': 'tr-TR',   // Turkish - Turkey
+  'uk': 'uk-UA',   // Ukrainian - Ukraine
+  'ur': 'ur-PK',   // Urdu - Pakistan
+  'uz': 'uz-UZ',   // Uzbek - Uzbekistan
+  'vi': 'vi-VN',   // Vietnamese - Vietnam
+  'cy': 'cy-GB',   // Welsh - Wales (uses GB)
+  'zu': 'zu-ZA'    // Zulu - South Africa
+}
+
 Hooks.ChatInput = {
   mounted() {
     this.el.addEventListener("keydown", (e) => {
@@ -123,83 +209,6 @@ Hooks.TextToSpeech = {
       return
     }
 
-    // Complete language to locale mapping (70 languages)
-    // Matches flag country codes from dialekt/languages.ex
-    const langToLocale = {
-      // Verified languages (15) - known good Web Speech API support
-      'en': 'en-GB',
-      'es': 'es-ES',
-      'fr': 'fr-FR',
-      'de': 'de-DE',
-      'it': 'it-IT',
-      'pt': 'pt-BR',
-      'ja': 'ja-JP',
-      'ko': 'ko-KR',
-      'zh': 'zh-CN',
-      'ru': 'ru-RU',
-      'ar': 'ar-SA',
-      'hi': 'hi-IN',
-      'nl': 'nl-NL',
-      'pl': 'pl-PL',
-      'sv': 'sv-SE',
-
-      // Additional languages (55+)
-      'af': 'af-ZA',   // Afrikaans - South Africa
-      'sq': 'sq-AL',   // Albanian - Albania
-      'hy': 'hy-AM',   // Armenian - Armenia
-      'az': 'az-AZ',   // Azerbaijani - Azerbaijan
-      'bn': 'bn-BD',   // Bengali - Bangladesh
-      'bs': 'bs-BA',   // Bosnian - Bosnia
-      'bg': 'bg-BG',   // Bulgarian - Bulgaria
-      'ca': 'ca-ES',   // Catalan - Spain
-      'hr': 'hr-HR',   // Croatian - Croatia
-      'cs': 'cs-CZ',   // Czech - Czech Republic
-      'da': 'da-DK',   // Danish - Denmark
-      'et': 'et-EE',   // Estonian - Estonia
-      'fi': 'fi-FI',   // Finnish - Finland
-      'ka': 'ka-GE',   // Georgian - Georgia
-      'el': 'el-GR',   // Greek - Greece
-      'gu': 'gu-IN',   // Gujarati - India
-      'ht': 'ht-HT',   // Haitian Creole - Haiti
-      'he': 'he-IL',   // Hebrew - Israel
-      'hu': 'hu-HU',   // Hungarian - Hungary
-      'is': 'is-IS',   // Icelandic - Iceland
-      'id': 'id-ID',   // Indonesian - Indonesia
-      'ga': 'ga-IE',   // Irish - Ireland
-      'kn': 'kn-IN',   // Kannada - India
-      'kk': 'kk-KZ',   // Kazakh - Kazakhstan
-      'km': 'km-KH',   // Khmer - Cambodia
-      'lv': 'lv-LV',   // Latvian - Latvia
-      'lt': 'lt-LT',   // Lithuanian - Lithuania
-      'mk': 'mk-MK',   // Macedonian - North Macedonia
-      'ms': 'ms-MY',   // Malay - Malaysia
-      'ml': 'ml-IN',   // Malayalam - India
-      'mt': 'mt-MT',   // Maltese - Malta
-      'mr': 'mr-IN',   // Marathi - India
-      'mn': 'mn-MN',   // Mongolian - Mongolia
-      'ne': 'ne-NP',   // Nepali - Nepal
-      'nb': 'nb-NO',   // Norwegian - Norway
-      'fa': 'fa-IR',   // Persian - Iran
-      'pa': 'pa-IN',   // Punjabi - India
-      'ro': 'ro-RO',   // Romanian - Romania
-      'sr': 'sr-RS',   // Serbian - Serbia
-      'sk': 'sk-SK',   // Slovak - Slovakia
-      'sl': 'sl-SI',   // Slovenian - Slovenia
-      'so': 'so-SO',   // Somali - Somalia
-      'sw': 'sw-KE',   // Swahili - Kenya
-      'tl': 'tl-PH',   // Tagalog - Philippines
-      'ta': 'ta-IN',   // Tamil - India
-      'te': 'te-IN',   // Telugu - India
-      'th': 'th-TH',   // Thai - Thailand
-      'tr': 'tr-TR',   // Turkish - Turkey
-      'uk': 'uk-UA',   // Ukrainian - Ukraine
-      'ur': 'ur-PK',   // Urdu - Pakistan
-      'uz': 'uz-UZ',   // Uzbek - Uzbekistan
-      'vi': 'vi-VN',   // Vietnamese - Vietnam
-      'cy': 'cy-GB',   // Welsh - Wales (uses GB)
-      'zu': 'zu-ZA'    // Zulu - South Africa
-    }
-
     // Languages with verified good Web Speech API support
     const verifiedLanguages = new Set([
       'en', 'es', 'fr', 'de', 'it', 'pt', 'ja', 'ko', 'zh',
@@ -230,7 +239,7 @@ Hooks.TextToSpeech = {
 
       // Create utterance with mapped language
       const utterance = new SpeechSynthesisUtterance(text)
-      utterance.lang = langToLocale[langCode] || langCode
+      utterance.lang = LANG_TO_LOCALE[langCode] || langCode
 
       // Optional: Add visual feedback
       this.el.style.opacity = '0.6'
@@ -256,6 +265,306 @@ Hooks.TextToSpeech = {
     if (this.handleClick) {
       this.el.removeEventListener('click', this.handleClick)
     }
+  }
+}
+
+Hooks.VoiceInput = {
+  mounted() {
+    this.isRecording = false
+    this.recognition = null
+    this.audioContext = null
+    this.analyser = null
+    this.microphone = null
+    this.animationId = null
+
+    // Check browser support
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition
+    if (!SpeechRecognition) {
+      this.el.style.display = 'none'
+      console.warn('Speech recognition not supported in this browser')
+      return
+    }
+
+    // Get languages from data attributes
+    this.targetLang = this.el.dataset.targetLang
+    this.nativeLang = this.el.dataset.nativeLang
+    this.currentLang = this.targetLang // Start with target language
+
+    // Get language indicator element
+    this.langIndicatorId = this.el.dataset.langIndicatorId
+    this.langIndicator = document.getElementById(this.langIndicatorId)
+
+    // Setup language toggle handler
+    if (this.langIndicator) {
+      this.handleLangToggle = () => this.toggleLanguage()
+      this.langIndicator.addEventListener('click', this.handleLangToggle)
+    }
+
+    // Store handler reference for cleanup
+    this.handleClick = () => this.toggleRecording()
+    this.el.addEventListener('click', this.handleClick)
+  },
+
+  toggleLanguage() {
+    // Switch between target and native language
+    this.currentLang = this.currentLang === this.targetLang ? this.nativeLang : this.targetLang
+    this.updateLanguageIndicator()
+
+    // If recording, restart recognition with new language
+    if (this.isRecording && this.recognition) {
+      this.recognition.stop()
+      setTimeout(() => {
+        if (this.isRecording) {
+          this.recognition.lang = this.getLangCode(this.currentLang)
+          try {
+            this.recognition.start()
+          } catch (error) {
+            console.error('Failed to restart recognition:', error)
+          }
+        }
+      }, VOICE_INPUT_CONFIG.LANG_SWITCH_DELAY_MS)
+    }
+  },
+
+  updateLanguageIndicator() {
+    if (this.langIndicator) {
+      const isTarget = this.currentLang === this.targetLang
+      this.langIndicator.textContent = this.currentLang.toUpperCase()
+      this.langIndicator.classList.toggle('target-lang', isTarget)
+      this.langIndicator.classList.toggle('native-lang', !isTarget)
+      this.langIndicator.title = isTarget
+        ? `Listening in target language (${this.currentLang}). Click to switch.`
+        : `Listening in native language (${this.currentLang}). Click to switch.`
+    }
+  },
+
+  toggleRecording() {
+    if (this.isRecording) {
+      this.stopRecording()
+    } else {
+      this.startRecording()
+    }
+  },
+
+  getLangCode(code) {
+    return LANG_TO_LOCALE[code] || code
+  },
+
+  async startRecording() {
+    try {
+      // Request microphone access
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+
+      // Get textarea reference
+      const textareaId = this.el.dataset.textareaId
+
+      // Setup speech recognition - simple mode, no real-time
+      const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition
+      this.recognition = new SpeechRecognition()
+      this.recognition.continuous = false
+      this.recognition.interimResults = false
+      this.recognition.lang = this.getLangCode(this.currentLang)
+      this.recognition.maxAlternatives = 1
+
+      // Handle final results only
+      this.recognition.onresult = (event) => {
+        const transcript = event.results[0][0].transcript
+
+        // Update textarea value directly
+        const textarea = document.getElementById(textareaId)
+        if (textarea) {
+          textarea.value = transcript
+
+          // Dispatch as if user typed
+          const inputEvent = new Event('input', { bubbles: true })
+          Object.defineProperty(inputEvent, 'target', {
+            writable: false,
+            value: { value: transcript }
+          })
+          textarea.dispatchEvent(inputEvent)
+        }
+      }
+
+      this.recognition.onerror = async (event) => {
+        console.error('Speech recognition error:', event.error)
+
+        if (event.error === 'no-speech') {
+          // No speech detected - this is normal, keep recording
+          return
+        } else if (event.error === 'aborted') {
+          // User stopped recording, don't show error
+          return
+        } else if (event.error === 'not-allowed') {
+          alert('Microphone access denied')
+          await this.stopRecording()
+        } else if (event.error === 'network') {
+          alert('Network error - speech recognition unavailable')
+          await this.stopRecording()
+        } else {
+          // Other errors - stop recording
+          console.error('Recognition error:', event.error)
+          await this.stopRecording()
+        }
+      }
+
+      this.recognition.onend = () => {
+        // Recognition ended but keep waveform visible
+        // Don't stop recording - let user decide when to stop
+      }
+
+      // Setup audio visualization
+      this.audioContext = new (window.AudioContext || window.webkitAudioContext)()
+      this.analyser = this.audioContext.createAnalyser()
+      this.analyser.fftSize = VOICE_INPUT_CONFIG.FFT_SIZE
+      this.microphone = this.audioContext.createMediaStreamSource(stream)
+      this.microphone.connect(this.analyser)
+
+      // Set recording state BEFORE drawing waveform
+      this.isRecording = true
+      this.stream = stream
+
+      // Get canvas element and cache color
+      const canvasId = this.el.dataset.canvasId
+      this.canvas = document.getElementById(canvasId)
+      if (this.canvas) {
+        this.canvasContext = this.canvas.getContext('2d')
+        this.cachedColor = getComputedStyle(document.documentElement).getPropertyValue('--color-base-content').trim() || 'oklch(21% 0.006 285.885)'
+        this.drawWaveform()
+      }
+
+      // Start recognition (can throw)
+      try {
+        this.recognition.start()
+      } catch (error) {
+        console.error('Failed to start speech recognition:', error)
+        this.isRecording = false
+        await this.cleanup()
+        throw error
+      }
+
+      // Update UI
+      this.el.classList.add('recording')
+      if (this.canvas) {
+        this.canvas.style.display = 'block'
+      }
+
+      // Show recording status and language indicator
+      const statusId = this.el.dataset.statusId
+      const status = document.getElementById(statusId)
+      if (status) {
+        status.style.display = 'flex'
+      }
+
+      // Update and show language indicator
+      this.updateLanguageIndicator()
+    } catch (error) {
+      console.error('Failed to start recording:', error)
+
+      let message = 'Could not start voice input. '
+      if (error.name === 'NotAllowedError') {
+        message += 'Microphone access denied. Please allow microphone access and try again.'
+      } else if (error.name === 'NotFoundError') {
+        message += 'No microphone found.'
+      } else {
+        message += error.message
+      }
+
+      alert(message)
+      await this.cleanup()
+    }
+  },
+
+  async stopRecording() {
+    if (this.recognition) {
+      this.recognition.stop()
+      this.recognition = null
+    }
+
+    await this.cleanup()
+
+    this.isRecording = false
+    this.el.classList.remove('recording')
+
+    if (this.canvas) {
+      this.canvas.style.display = 'none'
+    }
+
+    // Hide recording status
+    const statusId = this.el.dataset.statusId
+    const status = document.getElementById(statusId)
+    if (status) {
+      status.style.display = 'none'
+    }
+  },
+
+  async cleanup() {
+    if (this.animationId) {
+      cancelAnimationFrame(this.animationId)
+      this.animationId = null
+    }
+
+    if (this.stream) {
+      this.stream.getTracks().forEach(track => track.stop())
+      this.stream = null
+    }
+
+    if (this.microphone) {
+      this.microphone.disconnect()
+      this.microphone = null
+    }
+
+    if (this.audioContext) {
+      await this.audioContext.close()
+      this.audioContext = null
+    }
+
+    this.analyser = null
+  },
+
+  drawWaveform() {
+    if (!this.isRecording || !this.canvas) {
+      return
+    }
+
+    const bufferLength = this.analyser.frequencyBinCount
+    const dataArray = new Uint8Array(bufferLength)
+    this.analyser.getByteFrequencyData(dataArray)
+
+    const canvas = this.canvas
+    const canvasCtx = this.canvasContext
+    const width = canvas.width
+    const height = canvas.height
+
+    // Clear canvas
+    canvasCtx.clearRect(0, 0, width, height)
+
+    // Draw bars
+    const barCount = VOICE_INPUT_CONFIG.WAVEFORM_BAR_COUNT
+    const barWidth = width / barCount
+    const step = Math.floor(bufferLength / barCount)
+
+    for (let i = 0; i < barCount; i++) {
+      const value = dataArray[i * step]
+      const barHeight = (value / 255) * height * VOICE_INPUT_CONFIG.WAVEFORM_HEIGHT_SCALE
+      const x = i * barWidth
+      const y = (height - barHeight) / 2
+
+      // Use cached color
+      canvasCtx.fillStyle = this.cachedColor
+      canvasCtx.fillRect(x, y, barWidth - VOICE_INPUT_CONFIG.WAVEFORM_BAR_GAP, barHeight)
+    }
+
+    this.animationId = requestAnimationFrame(() => this.drawWaveform())
+  },
+
+  destroyed() {
+    if (this.handleClick) {
+      this.el.removeEventListener('click', this.handleClick)
+    }
+    if (this.handleLangToggle && this.langIndicator) {
+      this.langIndicator.removeEventListener('click', this.handleLangToggle)
+    }
+    this.cleanup()
   }
 }
 

--- a/lib/dialekt_web/live/chat_live.html.heex
+++ b/lib/dialekt_web/live/chat_live.html.heex
@@ -133,16 +133,59 @@
                 <div class="input-row">
                   <textarea
                     class="chat-ta"
-                    placeholder={"Write in #{@native && @native.name} or try #{@target && @target.name}..."}
+                    placeholder={"Type or use voice input to speak in #{@native && @native.name} or #{@target && @target.name}..."}
                     rows="1"
                     name="value"
                     value={@input}
                     phx-hook="ChatInput"
                     id="chat-input-empty"
                   ></textarea>
+                  <button
+                    type="button"
+                    class="voice-input-btn"
+                    phx-hook="VoiceInput"
+                    id="voice-input-empty"
+                    data-target-lang={@target && @target.code}
+                    data-native-lang={@native && @native.code}
+                    data-textarea-id="chat-input-empty"
+                    data-canvas-id="waveform-empty"
+                    data-status-id="recording-status-empty"
+                    data-lang-indicator-id="lang-indicator-empty"
+                    title="Voice input"
+                    aria-label="Voice input"
+                  >
+                    <.icon name="hero-microphone" class="size-5 mic-icon" />
+                    <.icon name="hero-stop-circle" class="size-5 stop-icon" />
+                  </button>
+                </div>
+                <canvas
+                  id="waveform-empty"
+                  class="waveform-canvas"
+                  width="400"
+                  height="60"
+                  aria-hidden="true"
+                >
+                </canvas>
+                <div
+                  id="recording-status-empty"
+                  class="recording-status"
+                  role="status"
+                  aria-live="polite"
+                  aria-atomic="true"
+                  style="display: none;"
+                >
+                  <span class="recording-dot"></span>
+                  <span>Recording...</span>
+                  <button
+                    type="button"
+                    id="lang-indicator-empty"
+                    class="lang-toggle-btn"
+                    title="Click to switch language"
+                  >
+                  </button>
                 </div>
                 <div class="input-hint">
-                  ↵ send · ⇧↵ new line · AI transliteration may contain mistakes
+                  ↵ send · ⇧↵ new line · voice input: click mic then language badge to switch · AI may contain mistakes
                 </div>
               </form>
             </div>
@@ -200,16 +243,59 @@
             <div class="input-row">
               <textarea
                 class="chat-ta"
-                placeholder={"Write in #{@native && @native.name} or try #{@target && @target.name}..."}
+                placeholder={"Type or use voice input to speak in #{@native && @native.name} or #{@target && @target.name}..."}
                 rows="1"
                 name="value"
                 value={@input}
                 phx-hook="ChatInput"
                 id="chat-input-active"
               ></textarea>
+              <button
+                type="button"
+                class="voice-input-btn"
+                phx-hook="VoiceInput"
+                id="voice-input-active"
+                data-target-lang={@target && @target.code}
+                data-native-lang={@native && @native.code}
+                data-textarea-id="chat-input-active"
+                data-canvas-id="waveform-active"
+                data-status-id="recording-status-active"
+                data-lang-indicator-id="lang-indicator-active"
+                title="Voice input"
+                aria-label="Voice input"
+              >
+                <.icon name="hero-microphone" class="size-5 mic-icon" />
+                <.icon name="hero-stop-circle" class="size-5 stop-icon" />
+              </button>
+            </div>
+            <canvas
+              id="waveform-active"
+              class="waveform-canvas"
+              width="400"
+              height="60"
+              aria-hidden="true"
+            >
+            </canvas>
+            <div
+              id="recording-status-active"
+              class="recording-status"
+              role="status"
+              aria-live="polite"
+              aria-atomic="true"
+              style="display: none;"
+            >
+              <span class="recording-dot"></span>
+              <span>Recording...</span>
+              <button
+                type="button"
+                id="lang-indicator-active"
+                class="lang-toggle-btn"
+                title="Click to switch language"
+              >
+              </button>
             </div>
             <div class="input-hint">
-              ↵ send · ⇧↵ new line · AI transliteration may contain mistakes
+              ↵ send · ⇧↵ new line · voice input: click mic then language badge to switch · AI may contain mistakes
             </div>
           </form>
         </div>


### PR DESCRIPTION
## Summary

Adds browser-based voice input feature with Web Speech API integration, allowing users to speak in either their native or target language during practice sessions.

## Features

- **VoiceInput LiveView hook** - Browser-based speech recognition using Web Speech API
- **Waveform visualization** - Canvas-based real-time audio visualization using Web Audio API
- **Language toggle** - Switch between native and target language while recording with visual indicator
- **70+ language support** - Comprehensive locale mapping matching TTS feature
- **Accessibility** - ARIA labels, live regions, reduced motion support
- **Visual feedback** - Recording status with pulsing animation, monochromatic color scheme
- **Error handling** - Graceful degradation, permission handling, network error recovery

## Implementation

- Shared `LANG_TO_LOCALE` constant for TTS and voice input (eliminates duplication)
- Extracted `VOICE_INPUT_CONFIG` constants for waveform rendering
- Proper resource cleanup (audio context, mic stream, event listeners)
- Error handling for permissions, network issues, browser compatibility
- Updated README with voice input usage instructions

## Browser Compatibility

- ✅ Chrome/Brave (requires disabling shields for localhost)
- ✅ Edge
- ⚠️ Safari (limited language support)
- ❌ Firefox (Web Speech API not supported)

## Breaking Changes

None - feature is additive only.